### PR TITLE
feat: Add Controls component for camera manipulation

### DIFF
--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -1,0 +1,21 @@
+
+import React from 'react';
+import { OrbitControls } from '@react-three/drei';
+
+const Controls = () => {
+
+
+    return(
+        <OrbitControls
+        minAzimuthAngle={-Math.PI / 2}
+        maxAzimuthAngle={Math.PI / 2}
+        minPolarAngle={0}
+        maxPolarAngle={Math.PI/2}
+        enableZoom={true}
+
+        />
+    )
+
+}
+
+export default Controls;


### PR DESCRIPTION
Add a new Controls component to handle camera manipulation in the scene. This component uses the OrbitControls from the @react-three/drei library to enable zooming and rotation of the camera. The component also sets the minimum and maximum azimuth and polar angles for the camera rotation.