### PR TITLE
feat: Adjust background height in Acidity and Pollution pages

### DIFF
--- a/src/pages/acidity/Acidity.css
+++ b/src/pages/acidity/Acidity.css
@@ -2,7 +2,7 @@
   background-image: url("/images/backgroundAcidity.jpg");
   background-size: cover;
   background-position: center;
-  min-height: 100vh;
+  min-height: 120vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/acidity/Acidity.jsx
+++ b/src/pages/acidity/Acidity.jsx
@@ -4,6 +4,7 @@ import Fish from "../../components/Fish/Fish";
 import LightFish from "../../components/ligths/LigthFish";
 import { BakeShadows, OrbitControls } from "@react-three/drei";
 import "./Acidity.css";
+import Header from "../../components/header/Header";
 
 const Acidity = () => {
   const canvasRef = useRef(null);
@@ -19,6 +20,9 @@ const Acidity = () => {
   };
 
   return (
+    
+  <div className="container-header">
+    <Header />
     <div className="acidity-container">
       <h1 className="acidity-title">Introducción</h1>
       <p className="acidity-description">
@@ -52,6 +56,7 @@ const Acidity = () => {
           <div className="loading">Haz clic en el botón para cargar el modelo...</div>
         )}
       </div>
+    </div>
     </div>
   );
 };

--- a/src/pages/pollution/Pollution.css
+++ b/src/pages/pollution/Pollution.css
@@ -1,7 +1,19 @@
-.container-pollution{  
+/* .container-pollution{  
     background: url(/images/backgroundPollution.jpg) no-repeat center center fixed;
     padding: 0.5px;
     text-align: center;
+    min-height: 120vh;
+} */
+.container-pollution{  
+  background: url(/images/backgroundPollution.jpg) no-repeat center center fixed;
+  background-size: cover;
+  background-position: center;
+  min-height: 140vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0px;
 }
   
   h1 {

--- a/src/pages/pollution/Pollution.jsx
+++ b/src/pages/pollution/Pollution.jsx
@@ -5,30 +5,32 @@ import React from "react";
 import "./Pollution.css";
 import Floor from "../../components/floor/Floor";
 import LightBigShark from "../../components/ligths/LightBigShark";
+import Header from "../../components/header/Header";
 
 //Este componente es el que se encarga de mostrar la escena del tiburón y el texto
 const SharkScene = () => {
   return (
     <Canvas
-    shadows
-    camera={{ position: [0, 2.5, 6], fov: 50 }}
-    fog={{ color: '#0b3d91', near: 5, far: 20 }}
+      shadows
+      camera={{ position: [0, 2.5, 6], fov: 50 }}
+      fog={{ color: "#0b3d91", near: 5, far: 20 }}
     >
-      <LightBigShark/>
+      <LightBigShark />
       <OrbitControls />
       <BigShark />
       <Floor />
       <Text
-      position={[0, 2, 0]}       // Posición del texto en el canvas
-      fontSize={0.2}              // Tamaño del texto
-      color="white"           // Color del texto
-      maxWidth={5}                // Ancho máximo antes de envolver
-      lineHeight={1.2}            // Altura de línea
-      anchorX="center"            // Ancla del texto en X
-      anchorY="middle"            // Ancla del texto en Y
-      font="./fonts/Poppins-Medium.ttf" // Fuente del texto
+        position={[0, 2, 0]} // Posición del texto en el canvas
+        fontSize={0.2} // Tamaño del texto
+        color="white" // Color del texto
+        maxWidth={5} // Ancho máximo antes de envolver
+        lineHeight={1.2} // Altura de línea
+        anchorX="center" // Ancla del texto en X
+        anchorY="middle" // Ancla del texto en Y
+        font="./fonts/Poppins-Medium.ttf" // Fuente del texto
       >
-        Actualmente, hay más de 5 billones de fragmentos de plástico en el océano.
+        Actualmente, hay más de 5 billones de fragmentos de plástico en el
+        océano.
       </Text>
     </Canvas>
   );
@@ -37,21 +39,24 @@ const SharkScene = () => {
 //Este componente es el que se encarga de mostrar la información de la contaminación del agua
 const Pollution = () => {
   return (
-    <div className="container-pollution" >
-      <h1>Contaminación del Agua</h1>
-      <div className="text-container">
-        <p>
-          La contaminación del agua es uno de los mayores problemas ambientales
-          del mundo actual. Cada día, millones de toneladas de desechos y
-          sustancias químicas dañinas son arrojadas a ríos, lagos y océanos,
-          poniendo en riesgo la vida acuática y la salud humana. Factores como
-          la industria textil contribuyen significativamente a este problema al
-          liberar contaminantes tóxicos que afectan la calidad del agua y dañan
-          los ecosistemas.
-        </p>
-      </div>
-      <div style={{ width: '100%', height: '500px', marginTop: '20px' }}>
-        <SharkScene />
+    <div className="container-header">
+      <Header />
+      <div className="container-pollution">
+        <h1>Contaminación del Agua</h1>
+        <div className="text-container">
+          <p>
+            La contaminación del agua es uno de los mayores problemas
+            ambientales del mundo actual. Cada día, millones de toneladas de
+            desechos y sustancias químicas dañinas son arrojadas a ríos, lagos y
+            océanos, poniendo en riesgo la vida acuática y la salud humana.
+            Factores como la industria textil contribuyen significativamente a
+            este problema al liberar contaminantes tóxicos que afectan la
+            calidad del agua y dañan los ecosistemas.
+          </p>
+        </div>
+        <div style={{ width: "100%", height: "500px", marginTop: "20px" }}>
+          <SharkScene />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- In Acidity.css, changed the min-height property from 100vh to 120vh to provide more vertical space for the content.
- In Pollution.css, adjusted the min-height property from 120vh to 140vh to accommodate the content and improve the layout.

This commit addresses the need to enhance the visual presentation of the Acidity and Pollution pages by adjusting the background height. The changes ensure that the content is displayed properly and improves the overall user experience.

![image](https://github.com/user-attachments/assets/3137fdb8-5a61-4c0d-8b18-6e3f094d1eda)

![image](https://github.com/user-attachments/assets/413b94f3-095e-4463-b70f-d3607cbe177f)
